### PR TITLE
T19 Remove `serverless-es-logs` plugin

### DIFF
--- a/fastapi/package-lock.json
+++ b/fastapi/package-lock.json
@@ -4713,54 +4713,6 @@
         }
       }
     },
-    "serverless-es-logs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-      "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "9.0.0",
-        "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        }
-      }
-    },
     "serverless-plugin-git-variables": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/serverless-plugin-git-variables/-/serverless-plugin-git-variables-5.1.0.tgz",

--- a/fastapi/package.json
+++ b/fastapi/package.json
@@ -5,7 +5,6 @@
   "dependencies": {},
   "devDependencies": {
     "serverless": "^2.68.0",
-    "serverless-es-logs": "^3.4.2",
     "serverless-plugin-git-variables": "^5.1.0",
     "serverless-prune-plugin": "^1.6.1",
     "serverless-python-requirements": "^5.1.1"

--- a/fastapi/serverless.yaml
+++ b/fastapi/serverless.yaml
@@ -37,7 +37,6 @@ functions:
       - http: 'ANY {proxy+}'
 
 plugins:
-  - serverless-es-logs
   - serverless-plugin-git-variables
   - serverless-prune-plugin
   - serverless-python-requirements

--- a/flask/package-lock.json
+++ b/flask/package-lock.json
@@ -4713,54 +4713,6 @@
         }
       }
     },
-    "serverless-es-logs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-      "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "9.0.0",
-        "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        }
-      }
-    },
     "serverless-plugin-git-variables": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/serverless-plugin-git-variables/-/serverless-plugin-git-variables-5.1.0.tgz",

--- a/flask/package.json
+++ b/flask/package.json
@@ -5,7 +5,6 @@
   "dependencies": {},
   "devDependencies": {
     "serverless": "^2.68.0",
-    "serverless-es-logs": "^3.4.2",
     "serverless-plugin-git-variables": "^5.1.0",
     "serverless-prune-plugin": "^1.6.1",
     "serverless-python-requirements": "^5.1.1"

--- a/flask/serverless.yaml
+++ b/flask/serverless.yaml
@@ -37,7 +37,6 @@ functions:
       - http: 'ANY {proxy+}'
 
 plugins:
-  - serverless-es-logs
   - serverless-plugin-git-variables
   - serverless-prune-plugin
   - serverless-python-requirements

--- a/python/package-lock.json
+++ b/python/package-lock.json
@@ -4713,54 +4713,6 @@
         }
       }
     },
-    "serverless-es-logs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/serverless-es-logs/-/serverless-es-logs-3.4.2.tgz",
-      "integrity": "sha512-sgc29A+itORPLw7tcUdqTKFdMVWfzZvXgIyAhdqDj3ICm7Az1llt+OsCvkkQYJvRdyhYPv8gOayF+SocMgAj+A==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "9.0.0",
-        "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        }
-      }
-    },
     "serverless-plugin-git-variables": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/serverless-plugin-git-variables/-/serverless-plugin-git-variables-5.1.0.tgz",

--- a/python/package.json
+++ b/python/package.json
@@ -5,7 +5,6 @@
   "dependencies": {},
   "devDependencies": {
     "serverless": "^2.68.0",
-    "serverless-es-logs": "^3.4.2",
     "serverless-plugin-git-variables": "^5.1.0",
     "serverless-prune-plugin": "^1.6.1",
     "serverless-python-requirements": "^5.1.1"

--- a/python/serverless.yaml
+++ b/python/serverless.yaml
@@ -38,7 +38,6 @@ functions:
         cors: true
 
 plugins:
-  - serverless-es-logs
   - serverless-plugin-git-variables
   - serverless-prune-plugin
   - serverless-python-requirements


### PR DESCRIPTION
Remove the `serverless-es-logs` plugin from all blueprints, as log group subscriptions are now created automatically for new Lambdas by the `okdata-log-group-subscriber` component.