### PR TITLE
Un-slim Python requirements

### DIFF
--- a/fastapi/serverless.yaml
+++ b/fastapi/serverless.yaml
@@ -57,7 +57,6 @@ custom:
   version: 0.1.0
   pythonRequirements:
     dockerizePip: non-linux
-    slim: true
     usePoetry: false
     dockerRunCmdExtraArgs: ['-v', '${env:PWD}/../okdata-aws:/okdata-aws']
   prune:

--- a/flask/serverless.yaml
+++ b/flask/serverless.yaml
@@ -61,7 +61,6 @@ custom:
     packRequirements: false
   pythonRequirements:
     dockerizePip: non-linux
-    slim: true
     usePoetry: false
   prune:
     automatic: true

--- a/python/serverless.yaml
+++ b/python/serverless.yaml
@@ -59,7 +59,6 @@ custom:
   version: 0.1.0
   pythonRequirements:
     dockerizePip: non-linux
-    slim: true
     usePoetry: false
   prune:
     automatic: true


### PR DESCRIPTION
`slim: true` is no longer working OOTB with our current cocktail of configured dependencies.