### PR TITLE
Upgrade to Python 3.13 + dependencies

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: pip install tox
       - name: Test with tox [fastapi]

--- a/fastapi/.github/workflows/deploy-dev.yml
+++ b/fastapi/.github/workflows/deploy-dev.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox

--- a/fastapi/.github/workflows/deploy-prod.yml
+++ b/fastapi/.github/workflows/deploy-prod.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox

--- a/fastapi/.github/workflows/pr-tests.yml
+++ b/fastapi/.github/workflows/pr-tests.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: pip install tox
       - name: Test with tox

--- a/fastapi/pyproject.toml
+++ b/fastapi/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py311']
+target-version = ['py313']
 # Keep exclude in sync with flake8 config in tox.ini
 exclude = '''
 /(

--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -14,14 +14,14 @@ attrs==25.3.0
     #   referencing
 aws-xray-sdk==2.14.0
     # via fastapi-blueprint (setup.py)
-boto3==1.39.0
+boto3==1.39.15
     # via okdata-aws
-botocore==1.39.0
+botocore==1.39.15
     # via
     #   aws-xray-sdk
     #   boto3
     #   s3transfer
-certifi==2025.6.15
+certifi==2025.7.14
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -29,11 +29,11 @@ charset-normalizer==3.4.2
     # via requests
 click==8.2.1
     # via uvicorn
-cryptography==45.0.4
+cryptography==45.0.5
     # via jwcrypto
 deprecation==2.1.0
     # via python-keycloak
-fastapi==0.115.14
+fastapi==0.116.1
     # via fastapi-blueprint (setup.py)
 h11==0.16.0
     # via uvicorn
@@ -45,7 +45,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via okdata-sdk
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -81,23 +81,23 @@ requests==2.32.4
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via python-keycloak
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-starlette==0.46.2
+starlette==0.47.2
     # via
     #   fastapi
     #   okdata-aws
 structlog==25.4.0
     # via okdata-aws
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   fastapi
     #   jwcrypto

--- a/fastapi/serverless.yaml
+++ b/fastapi/serverless.yaml
@@ -4,7 +4,7 @@ service: fastapi-blueprint
 
 provider:
   name: aws
-  runtime: python3.11
+  runtime: python3.13
   memorySize: 128
   region: eu-west-1
   stage: ${opt:stage, 'dev'}

--- a/fastapi/setup.py
+++ b/fastapi/setup.py
@@ -20,5 +20,5 @@ setup(
         "okdata-aws>=5,<6",
         "uvicorn",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.13",
 )

--- a/fastapi/tox.ini
+++ b/fastapi/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311,flake8,black
+envlist = py313,flake8,black
 
 [testenv]
 deps =

--- a/flask/.github/workflows/deploy-dev.yml
+++ b/flask/.github/workflows/deploy-dev.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox

--- a/flask/.github/workflows/deploy-prod.yml
+++ b/flask/.github/workflows/deploy-prod.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox

--- a/flask/.github/workflows/pr-tests.yml
+++ b/flask/.github/workflows/pr-tests.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: pip install tox
       - name: Test with tox

--- a/flask/pyproject.toml
+++ b/flask/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py311']
+target-version = ['py313']
 # Keep exclude in sync with flake8 config in tox.ini
 exclude = '''
 /(

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -10,7 +10,7 @@ aws-xray-sdk==2.14.0
     # via flask-blueprint (setup.py)
 blinker==1.9.0
     # via flask
-botocore==1.38.45
+botocore==1.39.15
     # via aws-xray-sdk
 click==8.2.1
     # via flask

--- a/flask/serverless.yaml
+++ b/flask/serverless.yaml
@@ -4,7 +4,7 @@ service: flask-blueprint
 
 provider:
   name: aws
-  runtime: python3.11
+  runtime: python3.13
   memorySize: 128
   region: eu-west-1
   stage: ${opt:stage, 'dev'}

--- a/flask/setup.py
+++ b/flask/setup.py
@@ -18,5 +18,5 @@ setup(
         "flask",
         "flask-restful",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.13",
 )

--- a/flask/tox.ini
+++ b/flask/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311,flake8,black
+envlist = py313,flake8,black
 
 [testenv]
 deps =

--- a/python/.github/workflows/deploy-dev.yml
+++ b/python/.github/workflows/deploy-dev.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox

--- a/python/.github/workflows/deploy-prod.yml
+++ b/python/.github/workflows/deploy-prod.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Python dependencies
         run: pip install tox
       - name: Test with tox

--- a/python/.github/workflows/pr-tests.yml
+++ b/python/.github/workflows/pr-tests.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install dependencies
         run: pip install tox
       - name: Test with tox

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py311']
+target-version = ['py313']
 # Keep exclude in sync with flake8 config in tox.ini
 exclude = '''
 /(

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,20 +12,20 @@ attrs==25.3.0
     #   referencing
 aws-xray-sdk==2.14.0
     # via python-blueprint (setup.py)
-boto3==1.38.45
+boto3==1.39.15
     # via okdata-aws
-botocore==1.38.45
+botocore==1.39.15
     # via
     #   aws-xray-sdk
     #   boto3
     #   s3transfer
-certifi==2025.6.15
+certifi==2025.7.14
     # via requests
 cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.2
     # via requests
-cryptography==45.0.4
+cryptography==45.0.5
     # via jwcrypto
 deprecation==2.1.0
     # via python-keycloak
@@ -37,7 +37,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via okdata-sdk
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -67,21 +67,21 @@ requests==2.32.4
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via python-keycloak
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-starlette==0.47.1
+starlette==0.47.2
     # via okdata-aws
 structlog==25.4.0
     # via okdata-aws
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via jwcrypto
 urllib3==2.5.0
     # via

--- a/python/serverless.yaml
+++ b/python/serverless.yaml
@@ -4,7 +4,7 @@ service: python-blueprint
 
 provider:
   name: aws
-  runtime: python3.11
+  runtime: python3.13
   memorySize: 1024
   region: eu-west-1
   stage: ${opt:stage, 'dev'}

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,5 +17,5 @@ setup(
         "aws-xray-sdk",
         "okdata-aws>=5,<6",
     ],
-    python_requires=">=3.11",
+    python_requires=">=3.13",
 )

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311,flake8,black
+envlist = py313,flake8,black
 
 [testenv]
 deps =


### PR DESCRIPTION
Upgrade Lambda runtimes to Python 3.13.

Also upgrade dependencies to get rid of known vulnerabilities.